### PR TITLE
fix(typescript): disable react/prop-types rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ["xo-typescript", "prettier/@typescript-eslint"],
+  rules: {
+    "react/prop-types": false,
+  },
 };


### PR DESCRIPTION
PropTypes is React's built-in runtime types system. While there are arguments to be made that PropTypes and TypeScript can and should both be used together, I currently believe that this is just too verbose and too annoying to set up and maintain. Given that we aren't authoring libraries that we plan to use in non-TypeScript environments, we are probably safe flying without PropTypes for now. If we change our minds, it is easy to revert this change at any time.